### PR TITLE
Print unhandled error before exit

### DIFF
--- a/lib/exception.js
+++ b/lib/exception.js
@@ -17,10 +17,14 @@ module.exports = {
                 if (!self.excCaught) {
                     self.excCaught = true;
                     logger.methods.sendException(err, null, function () {
-                        if (exit === true) {
-                            process.exit(1);
-                        }
+                        process.stderr.write((err.stack || err) + '\n', exitProcess);
                     });
+                }
+
+                function exitProcess() {
+                    if (exit === true) {
+                        process.exit(1);
+                    }
                 }
             });
         }());


### PR DESCRIPTION
It's no good when you do not see error caused process crash from it's output. Default behavior should be preserved.
