### PR TITLE
Fix: Stdin error due to IISNODE does not bind to stdin.

### DIFF
--- a/lib/exception.js
+++ b/lib/exception.js
@@ -57,8 +57,10 @@ module.exports = {
                     process.exit(1);
                 };
 
-            // Start reading from stdin so we don't exit instantly
-            process.stdin.resume();
+            // Start reading from stdin so we don't exit instantly, Windows IISNODE doesn't bind to stdin
+            if (!process.env.IISNODE_VERSION) {
+              process.stdin.resume();
+            }
 
             process.on('exit', function () {
                 if (!exit) {


### PR DESCRIPTION
Ignore reading from stdin if running IISNode (Such as on Azure App
Service)
